### PR TITLE
Add new option for onScrolledStateChange callback

### DIFF
--- a/demo/on-state-change-demo.html
+++ b/demo/on-state-change-demo.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>onStateChange Demo</title>
+    <style>
+      body {
+        margin: 0;
+        font-family: Arial, sans-serif;
+      }
+
+      /* MINIMAL REQUIRED STYLING */
+      header {
+        background-color: #333;
+        color: white;
+        text-align: center;
+        font-size: xx-large;
+        font-weight: bold;
+        padding: 20px;
+        margin-top: 0; /* REQUIRED: Reset top margin for proper edge alignment */
+        /* margin-bottom, margin-left, margin-right preserved */
+        transition: background-color 0.3s ease;
+      }
+
+      header.scrolled {
+        background-color: #c0392b;
+      }
+
+      footer {
+        background-color: #333;
+        color: white;
+        text-align: center;
+        font-size: xx-large;
+        font-weight: bold;
+        padding: 20px;
+        margin-bottom: 0; /* REQUIRED: Reset bottom margin for proper edge alignment */
+        transition: background-color 0.3s ease;
+      }
+
+      footer.scrolled {
+        background-color: #28a745; /* A different color for footer scrolled state */
+      }
+
+      main {
+        height: 2000px; /* Long content for scrolling */
+        padding: 20px;
+      }
+    </style>
+  </head>
+  <body>
+    <header id="header">Natural Sticky Header</header>
+
+    <main>
+      <h1>Scroll Test Content</h1>
+      <p>Scroll down and up to test the header behavior...</p>
+      <p>This content is 2000px tall to enable scrolling.</p>
+      <p>The header will change color when it becomes scrolled.</p>
+    </main>
+
+    <footer id="footer">Natural Sticky Footer</footer>
+
+    <script src="../dist/natural-sticky.top.min.js"></script>
+    <script src="../dist/natural-sticky.bottom.min.js"></script>
+    <script>
+      const header = document.getElementById('header');
+      const footer = document.getElementById('footer');
+
+      naturalStickyTop(header, {
+        onScrolledStateChange: isScrolled => {
+          console.log('Header scrolled state changed:', isScrolled);
+          if (isScrolled) {
+            header.classList.add('scrolled');
+          } else {
+            header.classList.remove('scrolled');
+          }
+        },
+      });
+
+      naturalStickyBottom(footer, {
+        onScrolledStateChange: isScrolled => {
+          console.log('Footer scrolled state changed:', isScrolled);
+          if (isScrolled) {
+            footer.classList.add('scrolled');
+          } else {
+            footer.classList.remove('scrolled');
+          }
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/src/bottom.ts
+++ b/src/bottom.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 /**
  * Attaches a natural hide/show behavior to a sticky element placed at the bottom.
  *
@@ -36,6 +37,7 @@ export function naturalStickyBottom(
     snapEagerness?: number;
     scrollThreshold?: number;
     reserveSpace?: boolean;
+    onScrolledStateChange?: (isScrolled: boolean) => void;
   }
 ) {
   let lastScrollY = window.scrollY;
@@ -49,6 +51,7 @@ export function naturalStickyBottom(
   const movePosition = reserveSpace ? 'relative' : 'absolute';
 
   const handleScroll = () => {
+    const previousIsFooterNotAtBottom = isFooterNotAtBottom;
     const currentScrollY = window.scrollY;
     const elementRect = element.getBoundingClientRect();
     const scrollStep = currentScrollY - lastScrollY;
@@ -104,6 +107,15 @@ export function naturalStickyBottom(
       element.style.position = movePosition;
       // Maintain visual continuity by positioning at current viewport bottom offset
       element.style.bottom = `${viewportBottomOffset}px`;
+    }
+
+    // If the footer isn't at the bottom of the document run the callback
+    isFooterNotAtBottom =
+      currentScrollY + viewportHeight <
+      documentHeight - (element.offsetHeight + 1);
+
+    if (previousIsFooterNotAtBottom !== isFooterNotAtBottom) {
+      options?.onScrolledStateChange?.(isFooterNotAtBottom);
     }
 
     lastScrollY = currentScrollY > 0 ? currentScrollY : 0;

--- a/src/top.ts
+++ b/src/top.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 /**
  * Attaches a natural hide/show behavior to a sticky element placed at the top.
  *
@@ -37,6 +38,7 @@ export function naturalStickyTop(
     snapEagerness?: number;
     scrollThreshold?: number;
     reserveSpace?: boolean;
+    onScrolledStateChange?: (isScrolled: boolean) => void;
   }
 ) {
   let lastScrollY = window.scrollY;
@@ -50,6 +52,7 @@ export function naturalStickyTop(
   const movePosition = reserveSpace ? 'relative' : 'absolute';
 
   const handleScroll = () => {
+    const previousIsHeaderNotAtTop = isHeaderNotAtTop;
     const currentScrollY = window.scrollY;
     const elementRect = element.getBoundingClientRect();
     const scrollStep = currentScrollY - lastScrollY;
@@ -98,6 +101,13 @@ export function naturalStickyTop(
       element.style.position = movePosition;
       // Position at current scroll position so element moves naturally with content
       element.style.top = `${currentScrollY}px`;
+    }
+
+    // If the header isn't at the top of the document run the callback
+    isHeaderNotAtTop = currentScrollY > element.offsetHeight + 1;
+
+    if (previousIsHeaderNotAtTop !== isHeaderNotAtTop) {
+      options?.onScrolledStateChange?.(isHeaderNotAtTop);
     }
 
     lastScrollY = currentScrollY > 0 ? currentScrollY : 0;


### PR DESCRIPTION
Hi! I took a shot at adding the feature I requested.  A new option `onScrolledStateChange` that accepts a callback and provides `isScrolled`. I set it up so the state change gets triggered when the header has been scrolled past its own height + 1px. Demo is included `on-state-change-demo.html`.

