### PR TITLE
ci(demo): use CDN for scripts in deployed demos

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -58,8 +58,10 @@ jobs:
 
       - name: Replace local scripts with CDN links in demo pages
         run: |
-          find demo -name "*.html" -exec sed -i "s|\.\./dist/natural-sticky\.top\.min\.js|https://cdn.jsdelivr.net/npm/natural-sticky@${{ steps.extract_version.outputs.version }}/dist/natural-sticky.top.min.js|g" {} +
-          find demo -name "*.html" -exec sed -i "s|\.\./dist/natural-sticky\.bottom\.min\.js|https://cdn.jsdelivr.net/npm/natural-sticky@${{ steps.extract_version.outputs.version }}/dist/natural-sticky.bottom.min.js|g" {} +
+          find demo -name "*.html" -exec sed -i \
+            -e "s|\.\./dist/natural-sticky\.top\.min\.js|https://cdn.jsdelivr.net/npm/natural-sticky@${{ steps.extract_version.outputs.version }}/dist/natural-sticky.top.min.js|g" \
+            -e "s|\.\./dist/natural-sticky\.bottom\.min\.js|https://cdn.jsdelivr.net/npm/natural-sticky@${{ steps.extract_version.outputs.version }}/dist/natural-sticky.bottom.min.js|g" \
+            {} +
 
       - name: Clean up unnecessary files for GitHub Pages
         run: |


### PR DESCRIPTION
- Replaces local script paths with JSDelivr CDN links in demo pages during the GitHub Pages deployment.
- This provides clearer, copy-paste-ready examples for users inspecting the live demos.
- Local development remains unaffected, still using local scripts for debugging and testing.